### PR TITLE
Use Slavic/Spanish-style quotation marks

### DIFF
--- a/server.js
+++ b/server.js
@@ -120,7 +120,7 @@ function checkArticleForNewTitle(newArticle, injectCategory) {
 function notifyTitleChanged(newArticle, existingArticle) {
   telemetry.increment('article_changed');
   let cat = newArticle.category ? '[' + newArticle.category + ']' : '';
-  let statusText = `${cat} De kop "${existingArticle.title.trim()}" is zojuist gewijzigd naar "${newArticle.title.trim()}" ${newArticle.guid}`;
+  let statusText = `${cat} De kop «${existingArticle.title.trim()}» is zojuist gewijzigd naar «${newArticle.title.trim()}» ${newArticle.guid}`;
   let params = { 
     status: statusText
   }


### PR DESCRIPTION
Use Slavic/Spanish-style quotation marks to prevent collisions with Dutch-style quotation marks used by the original headlines. This aims to address https://twitter.com/fdebanned/status/1056129669710442496.